### PR TITLE
Fix for blank page on Safari reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function fresh(req, res) {
   // unconditional request
   if (!modifiedSince && !noneMatch) return false;
 
-  // check for no-cache cache request directive
-  if (cc && cc.indexOf('no-cache') !== -1) return false;  
+  // check for no-cache or max-age=0 cache request directive
+  if (cc && (cc.indexOf('no-cache') !== -1 || cc.indexOf('max-age=0') !== -1)) return false;  
 
   // parse if-none-match
   if (noneMatch) noneMatch = noneMatch.split(/ *, */);


### PR DESCRIPTION
Often when Safari's reload button is used on a page served by Express, the result is a blank page.

Safari sends Cache-Control: max-age=0 on reload, rather than no-cache like other browsers. Node-fresh considers the cache stale when Cache-Control: no-cache headers are received, but it doesn't do the same for Cache-Control: max-age=0. This commit make the behavior the same in both cases. This updated code has been in heavy use by my team for the last 20 days, and we haven't encountered any problems with it.

http://stackoverflow.com/questions/18811286/nodejs-express-cache-and-304-status-code

http://stackoverflow.com/questions/1046966/whats-the-difference-between-cache-control-max-age-0-and-no-cache
