### PR TITLE
Add a max-age=0 patch for some versions of Safari.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ function fresh(req, res) {
   // check for no-cache cache request directive
   if (cc && cc.indexOf('no-cache') !== -1) return false;  
 
+  // check for max-age=0 cache request directive, which is sent by some
+  // versions of Safari when a page is reloaded.
+  if (cc && cc.indexOf('max-age=0') !== -1) return false;
+
   // parse if-none-match
   if (noneMatch) noneMatch = noneMatch.split(/ *, */);
 

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -124,8 +124,18 @@ describe('fresh(reqHeader, resHeader)', function(){
 
   describe('when requested with Cache-Control: no-cache', function(){
     it('should be stale', function(){
-      var req = { 'cache-control' : ' no-cache' };
-      var res = {};
+      // use matching etags so it would otherwise be fresh
+      var req = { 'if-none-match': 'tobi', 'cache-control' : 'no-cache' };
+      var res = { 'etag': 'tobi' };
+      fresh(req, res).should.be.false;
+    })
+  })
+
+  describe('when requested with Cache-Control: max-age=0', function(){
+    it('should be stale', function(){
+      // use matching etags so it would otherwise be fresh
+      var req = { 'if-none-match': 'tobi', 'cache-control' : 'max-age=0' };
+      var res = { 'etag': 'tobi' };
       fresh(req, res).should.be.false;
     })
   })


### PR DESCRIPTION
Some versions of Safari (at least my version, 7.0.3 OSX) will send
Cache-Control:max-age=0 instead of the usual Cache-Control:no-cache when
refreshing a page, after deleting the cache. It expects the server to
respond with up-to-date data. However, if the server response with a
304, then Safari will display a blank page to the user.

This very simple patch treats "max-age=0" the same as it does
"no-cache": it automatically treats the request as fresh, regardless of
other parameters.
