### PR TITLE
Fix bug in handling of invalid if-modified-since/last-modified values

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,19 @@ function fresh (reqHeaders, resHeaders) {
   if (modifiedSince) {
     var lastModifiedTimestamp = Date.parse(resHeaders['last-modified'])
     var modifiedSinceTimestamp = Date.parse(modifiedSince)
-    var modifiedStale = isNaN(lastModifiedTimestamp) || isNaN(modifiedSinceTimestamp) ||
-      lastModifiedTimestamp > modifiedSinceTimestamp
+
+    // If-Modified-Since request header has an invalid date value. Every falsy value except 0 is treated as invalid,
+    // because the default behavior of Date.parse to return NaN on invalid dates might have been monkey patched
+    if ((!modifiedSinceTimestamp && modifiedSinceTimestamp !== 0) || !isFinite(modifiedSinceTimestamp)) {
+      return false
+    }
+
+    // Last-Modified response header has an invalid date value
+    if ((!lastModifiedTimestamp && lastModifiedTimestamp !== 0) || !isFinite(lastModifiedTimestamp)) {
+      return false
+    }
+
+    var modifiedStale = lastModifiedTimestamp > modifiedSinceTimestamp
 
     if (modifiedStale) {
       return false

--- a/index.js
+++ b/index.js
@@ -69,8 +69,10 @@ function fresh (reqHeaders, resHeaders) {
 
   // if-modified-since
   if (modifiedSince) {
-    var lastModified = resHeaders['last-modified']
-    var modifiedStale = !lastModified || Date.parse(lastModified) > Date.parse(modifiedSince)
+    var lastModifiedTimestamp = Date.parse(resHeaders['last-modified'])
+    var modifiedSinceTimestamp = Date.parse(modifiedSince)
+    var modifiedStale = isNaN(lastModifiedTimestamp) || isNaN(modifiedSinceTimestamp) ||
+      lastModifiedTimestamp > modifiedSinceTimestamp
 
     if (modifiedStale) {
       return false

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -150,7 +150,9 @@ describe('fresh(reqHeaders, resHeaders)', function () {
       before(function () {
         Date.parse = function (str) {
           var date = dateParse(str)
-          return isNaN(date) ? false : date
+          // https://www.npmjs.com/package/datejs unconditionally patches Date.parse and returns null instead of NaN
+          // for invalid dates
+          return isNaN(date) ? null : date
         }
       })
 

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -119,6 +119,61 @@ describe('fresh(reqHeaders, resHeaders)', function () {
         assert.ok(!fresh(reqHeaders, resHeaders))
       })
     })
+
+    describe('with earliest possible If-Modified-Since date', function () {
+      it('should be stale', function () {
+        var reqHeaders = { 'if-modified-since': 'Thu, 01 Jan 1970 00:00:00 GMT' }
+        var resHeaders = { 'last-modified': 'Sat, 01 Jan 2000 00:00:00 GMT' }
+        assert.ok(!fresh(reqHeaders, resHeaders))
+      })
+    })
+
+    describe('with earliest possible Last-Modified date', function () {
+      it('should be fresh', function () {
+        var reqHeaders = { 'if-modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
+        var resHeaders = { 'last-modified': 'Thu, 01 Jan 1970 00:00:00 GMT' }
+        assert.ok(fresh(reqHeaders, resHeaders))
+      })
+    })
+
+    describe('with earliest possible Last-Modified and If-Modified-Since date', function () {
+      it('should be fresh', function () {
+        var reqHeaders = { 'if-modified-since': 'Thu, 01 Jan 1970 00:00:00 GMT' }
+        var resHeaders = { 'last-modified': 'Thu, 01 Jan 1970 00:00:00 GMT' }
+        assert.ok(fresh(reqHeaders, resHeaders))
+      })
+    })
+
+    describe('when Date.parse was monkey patched', function () {
+      var dateParse = Date.parse
+
+      before(function () {
+        Date.parse = function (str) {
+          var date = dateParse(str)
+          return isNaN(date) ? false : date
+        }
+      })
+
+      after(function () {
+        Date.parse = dateParse
+      })
+
+      describe('with invalid If-Modified-Since date', function () {
+        it('should be stale', function () {
+          var reqHeaders = { 'if-modified-since': 'foo' }
+          var resHeaders = { 'last-modified': 'Sat, 01 Jan 2000 00:00:00 GMT' }
+          assert.ok(!fresh(reqHeaders, resHeaders))
+        })
+      })
+
+      describe('with invalid Last-Modified date', function () {
+        it('should be stale', function () {
+          var reqHeaders = { 'if-modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
+          var resHeaders = { 'last-modified': 'foo' }
+          assert.ok(!fresh(reqHeaders, resHeaders))
+        })
+      })
+    })
   })
 
   describe('when requested with If-Modified-Since and If-None-Match', function () {

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -107,15 +107,15 @@ describe('fresh(reqHeaders, resHeaders)', function () {
     describe('with invalid If-Modified-Since date', function () {
       it('should be stale', function () {
         var reqHeaders = { 'if-modified-since': 'foo' }
-        var resHeaders = { 'modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
+        var resHeaders = { 'last-modified': 'Sat, 01 Jan 2000 00:00:00 GMT' }
         assert.ok(!fresh(reqHeaders, resHeaders))
       })
     })
 
-    describe('with invalid Modified-Since date', function () {
+    describe('with invalid Last-Modified date', function () {
       it('should be stale', function () {
         var reqHeaders = { 'if-modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
-        var resHeaders = { 'modified-since': 'foo' }
+        var resHeaders = { 'last-modified': 'foo' }
         assert.ok(!fresh(reqHeaders, resHeaders))
       })
     })

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -120,7 +120,7 @@ describe('fresh(reqHeaders, resHeaders)', function () {
       })
     })
 
-    describe('with earliest possible If-Modified-Since date', function () {
+    describe('with unix epoch (timestamp 0) in If-Modified-Since header', function () {
       it('should be stale', function () {
         var reqHeaders = { 'if-modified-since': 'Thu, 01 Jan 1970 00:00:00 GMT' }
         var resHeaders = { 'last-modified': 'Sat, 01 Jan 2000 00:00:00 GMT' }
@@ -128,7 +128,7 @@ describe('fresh(reqHeaders, resHeaders)', function () {
       })
     })
 
-    describe('with earliest possible Last-Modified date', function () {
+    describe('with unix epoch (timestamp 0) in Last-Modified header', function () {
       it('should be fresh', function () {
         var reqHeaders = { 'if-modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
         var resHeaders = { 'last-modified': 'Thu, 01 Jan 1970 00:00:00 GMT' }
@@ -136,7 +136,7 @@ describe('fresh(reqHeaders, resHeaders)', function () {
       })
     })
 
-    describe('with earliest possible Last-Modified and If-Modified-Since date', function () {
+    describe('with unix epoch (timestamp 0) in Last-Modified and If-Modified-Since header', function () {
       it('should be fresh', function () {
         var reqHeaders = { 'if-modified-since': 'Thu, 01 Jan 1970 00:00:00 GMT' }
         var resHeaders = { 'last-modified': 'Thu, 01 Jan 1970 00:00:00 GMT' }


### PR DESCRIPTION
Hi @dougwilson 

thanks for this very useful lib, but unfortunately I found two little bugs.
1. The tests for invalid values in if-modified-since/last-modified were broken and therefore covering up ...
2. a actual bug in the handling of invalid values in if-modified-since headers.
I split up the changes in two commits so it's easier for you the reproduce the behavior. With only the test changes applied you can see that one test is actually failing and with both commits applied all tests should be green again 👍 

Best regards,
Ben