### PR TITLE
Fix: Expect return true immediately if If-None-Match matches the ETag header (#35)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 ==========
 
   * Drop support for Node.js below 0.8
+  * Fix: Ignore `If-Modified-Since` in the presence of `If-None-Match`, according to [spec](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3-5). Fixes [#35](https://github.com/jshttp/fresh/issues/35)
 
 0.5.2 / 2017-09-13
 ==================

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = fresh
  * @public
  */
 
-function fresh (reqHeaders, resHeaders) {
+function fresh(reqHeaders, resHeaders) {
   // fields
   var modifiedSince = reqHeaders['if-modified-since']
   var noneMatch = reqHeaders['if-none-match']
@@ -48,7 +48,7 @@ function fresh (reqHeaders, resHeaders) {
     return false
   }
 
-  // if-none-match
+  // if-none-match takes precedent over if-modified-since
   if (noneMatch) {
     if (noneMatch === '*') {
       return true
@@ -59,17 +59,15 @@ function fresh (reqHeaders, resHeaders) {
       return false
     }
 
-    var etagFresh = false
     var matches = parseTokenList(noneMatch)
     for (var i = 0; i < matches.length; i++) {
       var match = matches[i]
       if (match === etag || match === 'W/' + etag || 'W/' + match === etag) {
-        etagFresh = true
-        break
+        return true
       }
     }
 
-    return etagFresh
+    return false
   }
 
   // if-modified-since
@@ -92,7 +90,7 @@ function fresh (reqHeaders, resHeaders) {
  * @private
  */
 
-function parseHttpDate (date) {
+function parseHttpDate(date) {
   var timestamp = date && Date.parse(date)
 
   // istanbul ignore next: guard against date.js Date.parse patching
@@ -108,7 +106,7 @@ function parseHttpDate (date) {
  * @private
  */
 
-function parseTokenList (str) {
+function parseTokenList(str) {
   var end = 0
   var list = []
   var start = 0

--- a/index.js
+++ b/index.js
@@ -49,26 +49,27 @@ function fresh (reqHeaders, resHeaders) {
   }
 
   // if-none-match
-  if (noneMatch && noneMatch !== '*') {
+  if (noneMatch) {
+    if (noneMatch === '*') {
+      return true
+    }
     var etag = resHeaders.etag
 
     if (!etag) {
       return false
     }
 
-    var etagStale = true
+    var etagStale = false
     var matches = parseTokenList(noneMatch)
     for (var i = 0; i < matches.length; i++) {
       var match = matches[i]
       if (match === etag || match === 'W/' + etag || 'W/' + match === etag) {
-        etagStale = false
+        etagStale = true
         break
       }
     }
 
-    if (etagStale) {
-      return false
-    }
+    return etagStale
   }
 
   // if-modified-since

--- a/index.js
+++ b/index.js
@@ -59,17 +59,17 @@ function fresh (reqHeaders, resHeaders) {
       return false
     }
 
-    var etagStale = false
+    var etagFresh = false
     var matches = parseTokenList(noneMatch)
     for (var i = 0; i < matches.length; i++) {
       var match = matches[i]
       if (match === etag || match === 'W/' + etag || 'W/' + match === etag) {
-        etagStale = true
+        etagFresh = true
         break
       }
     }
 
-    return etagStale
+    return etagFresh
   }
 
   // if-modified-since

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = fresh
  * @public
  */
 
-function fresh(reqHeaders, resHeaders) {
+function fresh (reqHeaders, resHeaders) {
   // fields
   var modifiedSince = reqHeaders['if-modified-since']
   var noneMatch = reqHeaders['if-none-match']
@@ -90,7 +90,7 @@ function fresh(reqHeaders, resHeaders) {
  * @private
  */
 
-function parseHttpDate(date) {
+function parseHttpDate (date) {
   var timestamp = date && Date.parse(date)
 
   // istanbul ignore next: guard against date.js Date.parse patching
@@ -106,7 +106,7 @@ function parseHttpDate(date) {
  * @private
  */
 
-function parseTokenList(str) {
+function parseTokenList (str) {
   var end = 0
   var list = []
   var start = 0

--- a/test/fresh.js
+++ b/test/fresh.js
@@ -139,10 +139,10 @@ describe('fresh(reqHeaders, resHeaders)', function () {
     })
 
     describe('when only ETag matches', function () {
-      it('should be stale', function () {
+      it('should be fresh', function () {
         var reqHeaders = { 'if-none-match': '"foo"', 'if-modified-since': 'Sat, 01 Jan 2000 00:00:00 GMT' }
         var resHeaders = { etag: '"foo"', 'last-modified': 'Sat, 01 Jan 2000 01:00:00 GMT' }
-        assert.ok(!fresh(reqHeaders, resHeaders))
+        assert.ok(fresh(reqHeaders, resHeaders))
       })
     })
 


### PR DESCRIPTION
### Main Changes
Expect  return true immediately if If-None-Match matches the ETag header.

### Context
Closes https://github.com/jshttp/fresh/issues/35